### PR TITLE
Ingest instances and allow non-string types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/
+.pytest_cache/

--- a/ingest/break_down.py
+++ b/ingest/break_down.py
@@ -59,10 +59,11 @@ def process_file(input_name, write_file=True):
         # Add the attributes shared by all entries in the glossary
         new_entry.update(base_data)
         new_entries.append(new_entry)
-        if write_file:
-            output_name = input_name.rsplit('.', 1)[0] + "-entries.json"
-            with open(output_name, 'w') as outfile:
-                header = '{ "index" : { "_id" : "' + entry["id"] + '" } }'
+    if write_file:
+        output_name = input_name.rsplit('.', 1)[0] + "-entries.json"
+        with open(output_name, 'w') as outfile:
+            for new_entry in new_entries:
+                header = '{ "index" : { "_id" : "' + new_entry["id"] + '" } }'
                 print(header, file=outfile)
                 print(json.dumps(new_entry), file=outfile)
     print("Finished processing {}".format(input_name))

--- a/ingest/break_down.py
+++ b/ingest/break_down.py
@@ -13,36 +13,30 @@ indirect_fields = {
 }
 
 
-def get_field_name(field_spec):
-    """Get just the field name from a spec which may also contain a target type."""
-    return field_spec[0] if not isinstance(field_spec, str) else field_spec
-
-
-def retrieve_and_cast(entry, spec):
-    """Get a specified field from an entry, possibly casting it to a given type.
-
-    :param entry: a dictionary representing an entry
-    :param spec: a field name (string) or a (field name, type) tuple
-    :return: the requested field of that entry, in the type specified or as a
-        string if spec is only a field name
-    """
-    if not isinstance(spec, str):
-        field, to_type = spec
-    else:  # if spec contains only the field name, not a type
-        field, to_type = spec, str
-    return to_type(entry[field])
+def name_and_type(field_spec):
+    """Break down a field spec into field name and type (string, by default)."""
+    # NB We cannot just try unwrapping the spec (and assume failure means there
+    # is no type), since strings can also be unwrapped, so the spec "gw" would
+    # be extracted as a name ("g") and a type ("w"). Hence, we check for strings
+    # explicitly.
+    if isinstance(field_spec, str):  # if the spec contains only the field name
+        return field_spec, str
+    else:  # if the spec also has a type
+        return field_spec[0], field_spec[1]
 
 
 def process_entry(entry):
     """Flatten the nested fields of an entry."""
     new_entry = {}
     for field in direct_fields:
-        new_entry[get_field_name(field)] = retrieve_and_cast(entry, field)
+        field_name, to_type = name_and_type(field)
+        new_entry[field_name] = to_type(entry[field_name])
     for top_field in indirect_fields:
         for inner_field in indirect_fields[top_field]:
-            new_field = "{}_{}".format(top_field, get_field_name(inner_field))
+            inner_field_name, to_type = name_and_type(inner_field)
+            new_field = "{}_{}".format(top_field, inner_field_name)
             new_entry[new_field] = [
-                        retrieve_and_cast(inner_entry, inner_field)
+                        to_type(inner_entry[inner_field_name])
                         for inner_entry
                         in entry.get(top_field, [])  # in case field is missing
             ]

--- a/ingest/break_down.py
+++ b/ingest/break_down.py
@@ -43,12 +43,20 @@ def process_file(input_name, write_file=True):
     with open(input_name, 'r') as infile:
         data = json.load(infile)
 
-    data.pop('instances', None)  # TODO link these later using the xis
+    instances = data["instances"]
     base_data = {key: data[key] for key in base_fields}
 
     new_entries = []
     for entry in data["entries"]:
+        # Create a flat entry from the nested norms, forms, senses etc.
         new_entry = process_entry(entry)
+        # Find the instance that is referred to by the entry. For now, just link
+        # the top-level reference rather than that of individual senses, norms
+        # etc. Every entry should have a corresponding instance in the glossary,
+        # so if something is missing this will throw a KeyError, which will let
+        # us know that there is something wrong with the glossary.
+        new_entry["instances"] = instances[entry["xis"]]
+        # Add the attributes shared by all entries in the glossary
         new_entry.update(base_data)
         new_entries.append(new_entry)
         if write_file:

--- a/ingest/break_down.py
+++ b/ingest/break_down.py
@@ -3,6 +3,12 @@ import json
 import sys
 
 
+# By default, we treat most glossary data as strings, but sometimes we want the
+# REST API to return a different type (for instance, counts should be integers).
+# The below sequences refer to fields in two ways: a field name just by itself
+# indicates that the field should be indexed as a string; alternatively, if the
+# name is accompanied by a type [e.g. ("icount", int)], that means that its
+# values should be converted to the given type.
 base_fields = ["project", "lang"]  # fields to copy into each entry
 direct_fields = ["gw", "headword", "cf", ("icount", int), "id"]
 indirect_fields = {

--- a/ingest/bulk_upload.py
+++ b/ingest/bulk_upload.py
@@ -16,12 +16,15 @@ def debug(msg):
     print(msg)
 
 
-def upload_file(es, input_file):
-    entries = process_file(input_file, write_file=False)
+def upload_entries(es, entries):
     for entry in entries:
         entry["_index"] = INDEX_NAME
         entry["_type"] = TYPE_NAME
     elasticsearch.helpers.bulk(es, entries)
+
+
+def upload_file(es, input_file):
+    upload_entries(es, process_file(input_file, write_file=False))
 
 
 if __name__ == "__main__":

--- a/tests/gloss-elx-out.json
+++ b/tests/gloss-elx-out.json
@@ -17,6 +17,9 @@
         "periods_p": [
             "Neo-Assyrian"
         ],
+        "instances": [
+            "dcclt/nineveh:P365771.134.1"
+        ],
         "project": "neo",
         "lang": "elx"
     },
@@ -38,6 +41,9 @@
         "periods_p": [
             "Neo-Assyrian"
         ],
+        "instances": [
+            "dcclt/nineveh:P365771.126.1"
+        ],
         "project": "neo",
         "lang": "elx"
     },
@@ -58,6 +64,9 @@
         ],
         "periods_p": [
             "Neo-Assyrian"
+        ],
+        "instances": [
+            "dcclt/nineveh:P365771.135.1"
         ],
         "project": "neo",
         "lang": "elx"
@@ -81,6 +90,10 @@
         ],
         "periods_p": [
             "Middle Babylonian"
+        ],
+        "instances": [
+            "dcclt:P332928.83.4",
+            "dcclt:P332948.43.4"
         ],
         "project": "neo",
         "lang": "elx"

--- a/tests/gloss-elx.json
+++ b/tests/gloss-elx.json
@@ -435,11 +435,32 @@
     ],
     "elx.r00002.p.s000": [
       "dcclt/nineveh:P365771.135.1"
+    ],
+    "xhu.r00005": [
+      "dcclt:P332928.83.4",
+      "dcclt:P332948.43.4"
+    ],
+    "xhu.r00005.p.s000": [
+      "dcclt:P332928.83.4",
+      "dcclt:P332948.43.4"
+    ],
+    "xhu.r00006": [
+      "dcclt:P332928.83.4"
+    ],
+    "xhu.r00006.p.s000": [
+      "dcclt:P332928.83.4"
+    ],
+    "xhu.r00007": [
+      "dcclt:P332948.43.4"
+    ],
+    "xhu.r00007.p.s000": [
+      "dcclt:P332948.43.4"
     ]
   },
   "summaries": {
     "elx.x000000": "<p class=\"summary\" id=\"elx.x000000\"><span class=\"summary\"><span class=\"summary-headword\"><a href=\"javascript:p3Article('/neo/cbd/elx/elx.x000000.html')\"><span class=\"cf\">kirir</span> [<span class=\"gw\">GODDESS</span>] <span class=\"cf\">N</span></a> (1x) </span>Neo-Assyrian  \"goddess\"</span></p>",
     "elx.x000008": "<p class=\"summary\" id=\"elx.x000008\"><span class=\"summary\"><span class=\"summary-headword\"><a href=\"javascript:p3Article('/neo/cbd/elx/elx.x000008.html')\"><span class=\"cf\">nap</span> [<span class=\"gw\">GOD</span>] <span class=\"cf\">N</span></a> (1x) </span>Neo-Assyrian  \"god\"</span></p>",
-    "elx.x000016": "<p class=\"summary\" id=\"elx.x000016\"><span class=\"summary\"><span class=\"summary-headword\"><a href=\"javascript:p3Article('/neo/cbd/elx/elx.x000016.html')\"><span class=\"cf\">usan</span> [<span class=\"gw\">GODDESS</span>] <span class=\"cf\">N</span></a> (1x) </span>Neo-Assyrian  \"goddess\"</span></p>"
+    "elx.x000016": "<p class=\"summary\" id=\"elx.x000016\"><span class=\"summary\"><span class=\"summary-headword\"><a href=\"javascript:p3Article('/neo/cbd/elx/elx.x000016.html')\"><span class=\"cf\">usan</span> [<span class=\"gw\">GODDESS</span>] <span class=\"cf\">N</span></a> (1x) </span>Neo-Assyrian  \"goddess\"</span></p>",
+    "xhu.x000040": "<p class=\"summary\" id=\"xhu.x000040\"><span class=\"summary\"><span class=\"summary-headword\"><a href=\"javascript:p3Article('/neo/cbd/xhu/xhu.x000040.html')\"><span class=\"cf\">apši</span> [<span class=\"gw\">SNAKE</span>] <span class=\"cf\">N</span></a> (2x) </span>Middle Babylonian  \"snake\"</span></p>"
   }
 }

--- a/tests/test_break_down.py
+++ b/tests/test_break_down.py
@@ -23,7 +23,7 @@ def test_process_file():
     for old_entry, new_entry in zip(original_data["entries"], new_entries):
         # Check that the direct fields are copied correctly
         for field in direct_fields:
-            new_entry[field] = old_entry[field]
+            assert new_entry[field] == old_entry[field]
         # And the same for the indirect fields
         # For an example of how the output should be like, look at gloss-elx-out.json
         for field in indirect_fields:

--- a/tests/test_break_down.py
+++ b/tests/test_break_down.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from ingest.break_down import (
-    get_field_name,
+    name_and_type,
     process_file,
     base_fields,
 )
@@ -13,7 +13,7 @@ from ingest.break_down import (
 def direct_fields():
     """Return the names of the fields directly copied into the new entries."""
     from ingest.break_down import direct_fields as fields
-    return [get_field_name(field) for field in fields]
+    return [name_and_type(field)[0] for field in fields]
 
 
 @pytest.fixture(scope="module")
@@ -21,7 +21,7 @@ def indirect_fields():
     """Return the indirect fields as a dictionary, but with any types removed."""
     from ingest.break_down import indirect_fields as fields
     return {
-        outer: [get_field_name(inner) for inner in fields[outer]]
+        outer: [name_and_type(inner)[0] for inner in fields[outer]]
         for outer in fields
     }
 

--- a/tests/test_break_down.py
+++ b/tests/test_break_down.py
@@ -31,3 +31,6 @@ def test_process_file():
                 nested_name = "{}_{}".format(field, nested_field)
                 for value in old_entry[field]:
                     assert value[nested_field] in new_entry[nested_name]
+        # Check that the top-level instances are correctly linked
+        correct_instances = original_data["instances"][old_entry["xis"]]
+        assert sorted(new_entry["instances"]) == sorted(correct_instances)

--- a/tests/test_break_down.py
+++ b/tests/test_break_down.py
@@ -56,3 +56,13 @@ def test_process_file(direct_fields, indirect_fields):
         # Check that the top-level instances are correctly linked
         correct_instances = original_data["instances"][old_entry["xis"]]
         assert sorted(new_entry["instances"]) == sorted(correct_instances)
+
+
+def test_name_and_type():
+    """Test that the breaking down of field specs into name and type works."""
+    # Check that we return the right name and str when there is no type given
+    assert name_and_type("field_name") == ("field_name", str)
+    # Check that we return the spec itself when it contains a type, e.g. float
+    assert name_and_type(("field_name", float)) == ("field_name", float)
+    # And check that this still works when the specified type is already str
+    assert name_and_type(("field_name", str)) == ("field_name", str)

--- a/tests/test_break_down.py
+++ b/tests/test_break_down.py
@@ -42,6 +42,8 @@ def test_process_file(direct_fields, indirect_fields):
         # Check that the direct fields are copied correctly (if seen as strings)
         for field in direct_fields:
             assert str(new_entry[field]) == old_entry[field]
+        # Also check that the count of instances has the right type
+        assert isinstance(new_entry["icount"], int)
         # And the same for the indirect fields
         # For an example of how the output should be like, look at gloss-elx-out.json
         for field in indirect_fields:

--- a/tests/test_bulk_upload.py
+++ b/tests/test_bulk_upload.py
@@ -1,0 +1,44 @@
+import time
+import json
+import warnings
+
+from elasticsearch import Elasticsearch, exceptions
+from elasticsearch.client import IndicesClient
+import pytest
+
+import ingest.bulk_upload
+
+
+INDEX_NAME = "oracc_test"
+
+
+@pytest.fixture
+def es(monkeypatch):
+    """An ElasticSearch client which also ensures we operate on a fake index."""
+    # NB: INDEX_NAME cannot be imported directly, or the patching won't work.
+    # Also note that this fixture cannot be module-scoped because monkeypatch is
+    # function-scoped.
+    monkeypatch.setattr(ingest.bulk_upload, "INDEX_NAME", INDEX_NAME)
+    assert ingest.bulk_upload.INDEX_NAME == INDEX_NAME  # just making sure
+    client = Elasticsearch()
+    yield client
+    try:
+        IndicesClient(client).delete(ingest.bulk_upload.INDEX_NAME)
+    except exceptions.NotFoundError:
+        warnings.warn("The ES index was never created (was anything indexed?)")
+
+
+@pytest.fixture(scope="module")
+def entries():
+    """An example list of JSON glossary entries."""
+    with open("tests/gloss-elx-out.json", "r") as entries_file:
+        return json.load(entries_file)
+
+
+def test_upload_entries(es, entries):
+    """Test that a list of entries is indexed correctly into ElasticSearch."""
+    assert ingest.bulk_upload.INDEX_NAME == INDEX_NAME  # paranoia
+    ingest.bulk_upload.upload_entries(es, entries)
+    time.sleep(2)  # a small delay to make sure the upload has finished
+    # Check that all documents have been uploaded
+    assert es.count(index=INDEX_NAME)["count"] == len(entries)


### PR DESCRIPTION
This mainly does three things:
- Includes the instance ids (`xis` fields) in the indexed data, which were previously ignored; this will be useful for linking to catalogue entries
- Allows fields to be indexed as any type, not just string (currently only used for the occurence count, which should be an integer)
- Adds a test for the indexing into ElasticSearch

Goes some way towards #4, and fixes #8.