### PR TITLE
Improved pagination

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language: python
 cache: pip
 

--- a/oracc_rest/search.py
+++ b/oracc_rest/search.py
@@ -7,6 +7,7 @@ class ESearch:
     FIELDNAMES = ['headword', 'gw', 'cf', 'forms_n', 'norms_n', 'senses_mng']
     TEXT_FIELDS = ['gw']  # fields with text content on which we can sort
     UNICODE_FIELDS = ['cf']  # fields which may contain non-ASCII characters
+    UNIQUE_FIELD = '_id'  # a field that identifies an entry, used to break ties
 
     def __init__(self):
         self.client = Elasticsearch()
@@ -37,7 +38,7 @@ class ESearch:
                                             query=word,
                                             fields=self.FIELDNAMES
                                             )
-                .sort(self._sort_field_name(sort_by, dir))
+                .sort(self._sort_field_name(sort_by, dir), self.UNIQUE_FIELD)
                 )
         return self._customise_and_run(search, count, after)
 
@@ -74,8 +75,7 @@ class ESearch:
         search = (
                 Search(using=self.client, index="oracc")
                 .query("match_all")
-                # TODO We should maybe sort on a tie-breaker field (eg _id) too...
-                .sort(self._sort_field_name(sort_by, dir))
+                .sort(self._sort_field_name(sort_by, dir), self.UNIQUE_FIELD)
                 )
         results = self._customise_and_run(search, count, after)
         return self._get_results(results)

--- a/oracc_rest/search.py
+++ b/oracc_rest/search.py
@@ -50,7 +50,7 @@ class ESearch:
         """
         result_list = [
             # Add a key called "sort" to each hit, containing its sort "score"
-            dict(**hit.to_dict(), sort=str(hit.meta.sort))
+            dict(**hit.to_dict(), sort=[str(s) for s in hit.meta.sort])
             for hit in results
         ]
         # This is probably better as a comprehension at the moment,


### PR DESCRIPTION
This will add some features to the web server so that the front-end can retrieve chunks of data of a specified size. The base functionality (using the ElasticSearch `search_after` feature) is there, but we need some improvements.

This will include:

- [x] Sorting on an additional field (`_doc` or `_id` or `_uid`) to break ties
- [ ] Parsing the `after` request parameter correctly, since its value will now be a list. As part of this:
    - [ ] making sure that the characters are correctly encoded (the ICU sorting scores are non-ASCII characters, and we may also need to (un)escape things)
    - [ ] passing a default value for the tie-break field if one is not specified
- [ ] Adding a way to retrieve the total number of hits, either when `after` is not specified (so with the first batch of results) or as a new endpoint; ideally we will do this without running a full search twice
- [ ] Updating the documentation (comments and README) with the new arguments and (if applicable) return style

This would also be a good time to:
- [ ] Add some tests for the server response, ensuring it matches the new format (cf #6)