### PR TITLE
Partial search

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ results. The list of fields currently searched is: `headword`, `gw`
 (guideword), `cf` (cuneiform), `senses.mng` (meaning), `forms.n` and `norms.n`
 (lemmatisations).
 
+The matching is not exact: an entry is considered to match a query word if it
+contains any term starting with the query in the relevant fields. For
+example, searching for "cat" would return words with either "cat" or "catch" in
+their meanings (among others).
+
+The query can also be a phrase of words separated by spaces. In this case, it
+will return results matching **any** of the words in the phrase.
+
 A second endpoint at `/search_all` can be used to retrieve all indexed entries.
 
 In both cases, the result is a JSON array with the full contents of each hit. If

--- a/oracc_rest/search.py
+++ b/oracc_rest/search.py
@@ -35,7 +35,8 @@ class ESearch:
                 Search(using=self.client, index="oracc").query(
                                             "multi_match",
                                             query=word,
-                                            fields=self.FIELDNAMES
+                                            fields=self.FIELDNAMES,
+                                            type="phrase_prefix"
                                             )
                 .sort(self._sort_field_name(sort_by, dir))
                 )

--- a/oracc_rest/search.py
+++ b/oracc_rest/search.py
@@ -8,15 +8,16 @@ class ESearch:
     TEXT_FIELDS = ['gw']  # fields with text content on which we can sort
     UNICODE_FIELDS = ['cf']  # fields which may contain non-ASCII characters
 
-    def __init__(self):
+    def __init__(self, index_name="oracc"):
         self.client = Elasticsearch()
+        self.index = index_name
 
     def _execute(self, word, fieldname):
         """
         Given a word and a fieldname, return all matching entries in the local
         ElasticSearch DB.
         """
-        search = Search(using=self.client, index="oracc").query(
+        search = Search(using=self.client, index=self.index).query(
                                     "match",
                                     **{fieldname: word})
         # To ensure that each result has a "sort" value (for consistency with
@@ -47,7 +48,7 @@ class ESearch:
         # To combine, we pass these subqueries as "should" arguments to a bool
         # query. This essentially gets the union of their results.
         search = (
-                Search(using=self.client, index="oracc")
+                Search(using=self.client, index=self.index)
                 .query("bool", should=subqueries)
                 .sort(self._sort_field_name(sort_by, dir))
                 )
@@ -84,7 +85,7 @@ class ESearch:
     def list_all(self, sort_by="cf", dir="asc", count=None, after=None):
         """Get a list of all entries."""
         search = (
-                Search(using=self.client, index="oracc")
+                Search(using=self.client, index=self.index)
                 .query("match_all")
                 # TODO We should maybe sort on a tie-breaker field (eg _id) too...
                 .sort(self._sort_field_name(sort_by, dir))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+import json
+import warnings
+
+from elasticsearch import Elasticsearch, exceptions
+from elasticsearch.client import IndicesClient
+import pytest
+
+import ingest.bulk_upload
+
+
+@pytest.fixture(scope="session")
+def index_name():
+    """The name of the fake index to use throughout the tests."""
+    return "oracc_test"
+
+
+@pytest.fixture
+def es(monkeypatch, index_name):
+    """An ElasticSearch client which also ensures we operate on a fake index."""
+    # NB: INDEX_NAME cannot be imported directly, or the patching won't work.
+    # Also note that this fixture cannot be module-scoped because monkeypatch is
+    # function-scoped.
+    monkeypatch.setattr(ingest.bulk_upload, "INDEX_NAME", index_name)
+    assert ingest.bulk_upload.INDEX_NAME == index_name  # just making sure
+    client = Elasticsearch()
+    yield client
+    try:
+        IndicesClient(client).delete(ingest.bulk_upload.INDEX_NAME)
+    except exceptions.NotFoundError:
+        warnings.warn("The ES index was never created (was anything indexed?)")
+
+
+@pytest.fixture(scope="module")
+def entries():
+    """An example list of JSON glossary entries."""
+    with open("tests/gloss-elx-out.json", "r") as entries_file:
+        return json.load(entries_file)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,19 +9,19 @@ import ingest.bulk_upload
 
 
 @pytest.fixture(scope="session")
-def index_name():
+def test_index_name():
     """The name of the fake index to use throughout the tests."""
     return "oracc_test"
 
 
 @pytest.fixture
-def es(monkeypatch, index_name):
+def es(monkeypatch, test_index_name):
     """An ElasticSearch client which also ensures we operate on a fake index."""
     # NB: INDEX_NAME cannot be imported directly, or the patching won't work.
     # Also note that this fixture cannot be module-scoped because monkeypatch is
     # function-scoped.
-    monkeypatch.setattr(ingest.bulk_upload, "INDEX_NAME", index_name)
-    assert ingest.bulk_upload.INDEX_NAME == index_name  # just making sure
+    monkeypatch.setattr(ingest.bulk_upload, "INDEX_NAME", test_index_name)
+    assert ingest.bulk_upload.INDEX_NAME == test_index_name  # just making sure
     client = Elasticsearch()
     yield client
     try:

--- a/tests/test_bulk_upload.py
+++ b/tests/test_bulk_upload.py
@@ -3,10 +3,10 @@ import time
 import ingest.bulk_upload
 
 
-def test_upload_entries(es, entries, index_name):
+def test_upload_entries(es, entries, test_index_name):
     """Test that a list of entries is indexed correctly into ElasticSearch."""
-    assert ingest.bulk_upload.INDEX_NAME == index_name  # paranoia
+    assert ingest.bulk_upload.INDEX_NAME == test_index_name  # paranoia
     ingest.bulk_upload.upload_entries(es, entries)
     time.sleep(2)  # a small delay to make sure the upload has finished
     # Check that all documents have been uploaded
-    assert es.count(index=index_name)["count"] == len(entries)
+    assert es.count(index=test_index_name)["count"] == len(entries)

--- a/tests/test_bulk_upload.py
+++ b/tests/test_bulk_upload.py
@@ -1,44 +1,12 @@
-import json
 import time
-import warnings
-
-from elasticsearch import Elasticsearch, exceptions
-from elasticsearch.client import IndicesClient
-import pytest
 
 import ingest.bulk_upload
 
 
-INDEX_NAME = "oracc_test"
-
-
-@pytest.fixture
-def es(monkeypatch):
-    """An ElasticSearch client which also ensures we operate on a fake index."""
-    # NB: INDEX_NAME cannot be imported directly, or the patching won't work.
-    # Also note that this fixture cannot be module-scoped because monkeypatch is
-    # function-scoped.
-    monkeypatch.setattr(ingest.bulk_upload, "INDEX_NAME", INDEX_NAME)
-    assert ingest.bulk_upload.INDEX_NAME == INDEX_NAME  # just making sure
-    client = Elasticsearch()
-    yield client
-    try:
-        IndicesClient(client).delete(ingest.bulk_upload.INDEX_NAME)
-    except exceptions.NotFoundError:
-        warnings.warn("The ES index was never created (was anything indexed?)")
-
-
-@pytest.fixture(scope="module")
-def entries():
-    """An example list of JSON glossary entries."""
-    with open("tests/gloss-elx-out.json", "r") as entries_file:
-        return json.load(entries_file)
-
-
-def test_upload_entries(es, entries):
+def test_upload_entries(es, entries, index_name):
     """Test that a list of entries is indexed correctly into ElasticSearch."""
-    assert ingest.bulk_upload.INDEX_NAME == INDEX_NAME  # paranoia
+    assert ingest.bulk_upload.INDEX_NAME == index_name  # paranoia
     ingest.bulk_upload.upload_entries(es, entries)
     time.sleep(2)  # a small delay to make sure the upload has finished
     # Check that all documents have been uploaded
-    assert es.count(index=INDEX_NAME)["count"] == len(entries)
+    assert es.count(index=index_name)["count"] == len(entries)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,4 +1,17 @@
+import time
+
+import pytest
+
+import ingest.bulk_upload
 from oracc_rest import ESearch
+
+
+@pytest.fixture
+def uploaded_entries(es, entries):
+    """A fixture to ensure that the test glossary entries have been uploaded."""
+    ingest.bulk_upload.upload_entries(es, entries)
+    time.sleep(2)  # a small delay to make sure the upload has finished
+    return entries
 
 
 def test_sort_field_name():
@@ -14,3 +27,28 @@ def test_sort_field_name():
     ]
     for (field, dir, expected) in combinations:
         assert search._sort_field_name(field, dir) == expected
+
+
+def test_list_all(uploaded_entries, test_index_name):
+    """Check that the list_all endpoint returns all the entries."""
+    search = ESearch(index_name=test_index_name)
+    # Note that we have to sort by something other than cf (the default),
+    # because the upload process for the tests does not create the cf.sort
+    # field.
+    assert len(search.list_all(sort_by="gw")) == len(uploaded_entries)
+
+
+def test_multi_word_search(uploaded_entries, test_index_name):
+    """
+    Check that the main endpoint gives the right results for basic use cases.
+
+    Specifically, this tests that partial matching works correctly, and that
+    a multi-word query gives the union of results, as expected.
+    """
+    search = ESearch(index_name=test_index_name)
+    # Check that we get partial matches ("god" should also match "goddess")
+    assert len(search.run("god", sort_by="gw")) == 3
+    # Check that a multi-word query returns results matching any word in it
+    assert len(search.run("god snake", sort_by="gw")) == 4
+    # Check that if an entry matches two query words, it is only returned once
+    assert len(search.run("god usan", sort_by="gw")) == 3

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -45,10 +45,15 @@ def test_multi_word_search(uploaded_entries, test_index_name):
     Specifically, this tests that partial matching works correctly, and that
     a multi-word query gives the union of results, as expected.
     """
+    # The test glossary that we use contains two entries for the word "goddess",
+    # one for "god", and one for "snake".
     search = ESearch(index_name=test_index_name)
     # Check that we get partial matches ("god" should also match "goddess")
     assert len(search.run("god", sort_by="gw")) == 3
+    # Check that the whole query word has to match (just in case!)
+    assert len(search.run("goddess", sort_by="gw")) == 2
     # Check that a multi-word query returns results matching any word in it
     assert len(search.run("god snake", sort_by="gw")) == 4
     # Check that if an entry matches two query words, it is only returned once
+    # ("usan" is one of the words meaning "goddess")
     assert len(search.run("god usan", sort_by="gw")) == 3


### PR DESCRIPTION
Fixes #17, partially addresses #6.

This makes it so partial matches will be returned - for example, searching for `cat` will match both `cat` and `catch` (in any of the searched fields). As before, if a user searches for multiple words (separated by spaces), this will return results matching any of those words.

Main parts:
- [x] Change from exact to partial matching
- [x] Search for words individually rather than treating the whole phrase as one prefix
- [x] Add tests for some simple cases