### PR TITLE
Preprocess glossaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ install all necessary Python modules:
 pip install -r requirements.txt
 ```
 
+### Installing jq
+
+We use the [jq](https://stedolan.github.io/jq/) tool to efficiently preprocess
+large glossary files. This can be easily installed through a package manager:
+* OS X: `brew install jq`
+* Ubuntu: `sudo apt-get install jq`
+
+For more installation instructions and options, see
+[the tool's official page](https://stedolan.github.io/jq/download/).
+
 ### ElasticSearch management
 To store Oracc's texts and their related metadata, we use
 [ElasticSearch](https://www.elastic.co/products/elasticsearch). The code in

--- a/ingest/break_down.py
+++ b/ingest/break_down.py
@@ -1,5 +1,7 @@
 """A module for breaking down a glossary into individual entries."""
 import json
+import os
+import subprocess
 import sys
 
 
@@ -60,7 +62,18 @@ def process_file(input_name, write_file=True):
     :param write_file: whether to write the entries in a new file, to be used later
     :return: a list of the new individual entries, as dictionaries
     """
-    with open(input_name, 'r') as infile:
+    # The glossaries contain a lot of information that we do not use.
+    # Sometimes this can make them too large to load in memory. Therefore,
+    # we first preprocess each file to remove the fields we do not need.
+    temp_file = input_name.rsplit('.', 1)[0] + "-preprocessed.json"
+    filter_file = os.path.join("ingest", "remove_unused.jq")
+    with open(temp_file, 'w') as tempfile:
+        subprocess.Popen(
+            ["jq", "-f", filter_file, input_name],
+            stdout=tempfile
+        )
+
+    with open(temp_file, 'r') as infile:
         data = json.load(infile)
 
     instances = data["instances"]

--- a/ingest/break_down.py
+++ b/ingest/break_down.py
@@ -3,6 +3,7 @@ import json
 import os
 import subprocess
 import sys
+import warnings
 
 
 # By default, we treat most glossary data as strings, but sometimes we want the
@@ -81,9 +82,10 @@ def process_glossary_data(data):
         try:
             new_entry["instances"] = instances[entry["xis"]]
         except KeyError:
-            print("Could not find the instance {} for entry {}!".format(
-                    entry["xis"], entry["headword"]
-            ))
+            warnings.warn(
+                "Could not find the instance {} for entry {}!".format(
+                    entry["xis"], entry["headword"])
+            )
             continue
         # Add the attributes shared by all entries in the glossary
         new_entry.update(base_data)

--- a/ingest/break_down.py
+++ b/ingest/break_down.py
@@ -52,31 +52,23 @@ def process_entry(entry):
     return new_entry
 
 
-def process_file(input_name, write_file=True):
+def process_glossary_data(data):
     """
-    Process all entries in a glossary file, extracting the common information to
-    create entries that can be individually indexed. Optionally create a new
-    file with the entries that can be uploaded manually.
+    Process a glossary and link the entries to their instances.
 
-    :param input_name: the name of the glossary JSON file
-    :param write_file: whether to write the entries in a new file, to be used later
-    :return: a list of the new individual entries, as dictionaries
+    Glossaries contain entries in a nested format. This step extracts the
+    relevant information at various nesting levels, and produces a list of
+    entries with "flattened" fields. It also incorporates the information from
+    the instances part of the glossary into the relevant entries.
+    Any entries referring to non-existent instances will be ignored. A warning
+    will be raised in those cases.
+
+    :param data: a dictionary representing a glossary, including the instances.
+    :return: a list of entries, flattened and linked to instances when possible.
+
     """
-    # The glossaries contain a lot of information that we do not use.
-    # Sometimes this can make them too large to load in memory. Therefore,
-    # we first preprocess each file to remove the fields we do not need.
-    filter_file = os.path.join("ingest", "remove_unused.jq")
-    s = subprocess.run(
-            ["jq", "-f", filter_file, input_name],
-            stdout=subprocess.PIPE
-    )
-
-    # We need to decode the output to a string if not working in binary mode
-    data = json.loads(s.stdout.decode("utf8"))
-
     instances = data["instances"]
     base_data = {key: data[key] for key in base_fields}
-
     new_entries = []
     for entry in data["entries"]:
         # Create a flat entry from the nested norms, forms, senses etc.
@@ -96,6 +88,36 @@ def process_file(input_name, write_file=True):
         # Add the attributes shared by all entries in the glossary
         new_entry.update(base_data)
         new_entries.append(new_entry)
+    return new_entries
+
+
+def preprocess_glossary(glossary_filename):
+    """Remove unused fields from a glossary and return it as a dictionary."""
+    filter_file = os.path.join("ingest", "remove_unused.jq")
+    s = subprocess.run(
+            ["jq", "-f", filter_file, glossary_filename],
+            stdout=subprocess.PIPE
+    )
+    # We need to decode the output to a string if not working in binary mode
+    return json.loads(s.stdout.decode("utf8"))
+
+
+def process_file(input_name, write_file=True):
+    """
+    Process all entries in a glossary file, extracting the common information to
+    create entries that can be individually indexed. Optionally create a new
+    file with the entries that can be uploaded manually.
+
+    :param input_name: the name of the glossary JSON file
+    :param write_file: whether to write the entries in a new file, to be used later
+    :return: a list of the new individual entries, as dictionaries
+    """
+    # The glossaries contain a lot of information that we do not use.
+    # Sometimes this can make them too large to load in memory. Therefore,
+    # we first preprocess each file to remove the fields we do not need.
+    data = preprocess_glossary(input_name)
+
+    new_entries = process_glossary_data(data)
     if write_file:
         output_name = input_name.rsplit('.', 1)[0] + "-entries.json"
         with open(output_name, 'w') as outfile:

--- a/ingest/break_down.py
+++ b/ingest/break_down.py
@@ -75,7 +75,13 @@ def process_file(input_name, write_file=True):
         # etc. Every entry should have a corresponding instance in the glossary,
         # so if something is missing this will throw a KeyError, which will let
         # us know that there is something wrong with the glossary.
-        new_entry["instances"] = instances[entry["xis"]]
+        try:
+            new_entry["instances"] = instances[entry["xis"]]
+        except KeyError:
+            print("Could not find the instance {} for entry {}!".format(
+                    entry["xis"], entry["headword"]
+            ))
+            continue
         # Add the attributes shared by all entries in the glossary
         new_entry.update(base_data)
         new_entries.append(new_entry)

--- a/ingest/break_down.py
+++ b/ingest/break_down.py
@@ -65,18 +65,14 @@ def process_file(input_name, write_file=True):
     # The glossaries contain a lot of information that we do not use.
     # Sometimes this can make them too large to load in memory. Therefore,
     # we first preprocess each file to remove the fields we do not need.
-    temp_file = input_name.rsplit('.', 1)[0] + "-preprocessed.json"
     filter_file = os.path.join("ingest", "remove_unused.jq")
-    with open(temp_file, 'w') as tempfile:
-        s = subprocess.run(
-                ["jq", "-f", filter_file, input_name],
-                stdout=subprocess.PIPE
-        )
-        # We need to decode this to a string if not working in binary mode
-        print(s.stdout.decode("utf8"), file=tempfile)
+    s = subprocess.run(
+            ["jq", "-f", filter_file, input_name],
+            stdout=subprocess.PIPE
+    )
 
-    with open(temp_file, 'r') as infile:
-        data = json.load(infile)
+    # We need to decode the output to a string if not working in binary mode
+    data = json.loads(s.stdout.decode("utf8"))
 
     instances = data["instances"]
     base_data = {key: data[key] for key in base_fields}

--- a/ingest/break_down.py
+++ b/ingest/break_down.py
@@ -68,10 +68,12 @@ def process_file(input_name, write_file=True):
     temp_file = input_name.rsplit('.', 1)[0] + "-preprocessed.json"
     filter_file = os.path.join("ingest", "remove_unused.jq")
     with open(temp_file, 'w') as tempfile:
-        subprocess.Popen(
-            ["jq", "-f", filter_file, input_name],
-            stdout=tempfile
+        s = subprocess.run(
+                ["jq", "-f", filter_file, input_name],
+                stdout=subprocess.PIPE
         )
+        # We need to decode this to a string if not working in binary mode
+        print(s.stdout.decode("utf8"), file=tempfile)
 
     with open(temp_file, 'r') as infile:
         data = json.load(infile)

--- a/ingest/remove_unused.jq
+++ b/ingest/remove_unused.jq
@@ -1,0 +1,16 @@
+{
+  project,
+  lang,
+  entries: [
+    .entries[]
+    |
+    {
+     headword, id, icount, xis, cf, gw,
+     forms: [{n: .forms[]?.n}],
+     norms: [{n: .norms[]?.n}],
+     senses: [{mng: .senses[]?.mng}],
+     periods: [{p: .periods[]?.p}]
+    }
+  ],
+  instances
+}

--- a/tests/gloss-elx-preprocessed.json
+++ b/tests/gloss-elx-preprocessed.json
@@ -1,0 +1,165 @@
+{
+  "project": "neo",
+  "lang": "elx",
+  "entries": [
+    {
+      "headword": "kirir[goddess]N",
+      "id": "elx.x000000",
+      "icount": "1",
+      "xis": "elx.r00000",
+      "cf": "kirir",
+      "gw": "goddess",
+      "forms": [
+        {
+          "n": "ki-ri-ir"
+        }
+      ],
+      "norms": [
+        {
+          "n": "kirir"
+        }
+      ],
+      "senses": [
+        {
+          "mng": "goddess"
+        }
+      ],
+      "periods": [
+        {
+          "p": "Neo-Assyrian"
+        }
+      ]
+    },
+    {
+      "headword": "nap[god]N",
+      "id": "elx.x000008",
+      "icount": "1",
+      "xis": "elx.r00001",
+      "cf": "nap",
+      "gw": "god",
+      "forms": [
+        {
+          "n": "nap"
+        }
+      ],
+      "norms": [
+        {
+          "n": "nap"
+        }
+      ],
+      "senses": [
+        {
+          "mng": "god"
+        }
+      ],
+      "periods": [
+        {
+          "p": "Neo-Assyrian"
+        }
+      ]
+    },
+    {
+      "headword": "usan[goddess]N",
+      "id": "elx.x000016",
+      "icount": "1",
+      "xis": "elx.r00002",
+      "cf": "usan",
+      "gw": "goddess",
+      "forms": [
+        {
+          "n": "{u₂-sa-an}usan₄"
+        }
+      ],
+      "norms": [
+        {
+          "n": "usan"
+        }
+      ],
+      "senses": [
+        {
+          "mng": "goddess"
+        }
+      ],
+      "periods": [
+        {
+          "p": "Neo-Assyrian"
+        }
+      ]
+    },
+    {
+      "headword": "apši[snake]N",
+      "id": "xhu.x000040",
+      "icount": "2",
+      "xis": "xhu.r00005",
+      "cf": "apši",
+      "gw": "snake",
+      "forms": [
+        {
+          "n": "ap-še"
+        },
+        {
+          "n": "ap-ši"
+        }
+      ],
+      "norms": [
+        {
+          "n": "apše"
+        },
+        {
+          "n": "apši"
+        }
+      ],
+      "senses": [
+        {
+          "mng": "snake"
+        }
+      ],
+      "periods": [
+        {
+          "p": "Middle Babylonian"
+        }
+      ]
+    }
+  ],
+  "instances": {
+    "elx.r00000": [
+      "dcclt/nineveh:P365771.134.1"
+    ],
+    "elx.r00001": [
+      "dcclt/nineveh:P365771.126.1"
+    ],
+    "elx.r00002": [
+      "dcclt/nineveh:P365771.135.1"
+    ],
+    "elx.r00000.p.s000": [
+      "dcclt/nineveh:P365771.134.1"
+    ],
+    "elx.r00001.p.s000": [
+      "dcclt/nineveh:P365771.126.1"
+    ],
+    "elx.r00002.p.s000": [
+      "dcclt/nineveh:P365771.135.1"
+    ],
+    "xhu.r00005": [
+      "dcclt:P332928.83.4",
+      "dcclt:P332948.43.4"
+    ],
+    "xhu.r00005.p.s000": [
+      "dcclt:P332928.83.4",
+      "dcclt:P332948.43.4"
+    ],
+    "xhu.r00006": [
+      "dcclt:P332928.83.4"
+    ],
+    "xhu.r00006.p.s000": [
+      "dcclt:P332928.83.4"
+    ],
+    "xhu.r00007": [
+      "dcclt:P332948.43.4"
+    ],
+    "xhu.r00007.p.s000": [
+      "dcclt:P332948.43.4"
+    ]
+  }
+}
+

--- a/tests/gloss-missing-instance.json
+++ b/tests/gloss-missing-instance.json
@@ -1,0 +1,67 @@
+{
+  "project": "neo",
+  "lang": "elx",
+  "entries": [
+    {
+      "headword": "kirir[goddess]N",
+      "id": "elx.x000000",
+      "icount": "1",
+      "xis": "elx.non_existent",
+      "cf": "kirir",
+      "gw": "goddess",
+      "forms": [
+        {
+          "n": "ki-ri-ir"
+        }
+      ],
+      "norms": [
+        {
+          "n": "kirir"
+        }
+      ],
+      "senses": [
+        {
+          "mng": "goddess"
+        }
+      ],
+      "periods": [
+        {
+          "p": "Neo-Assyrian"
+        }
+      ]
+    },
+    {
+      "headword": "nap[god]N",
+      "id": "elx.x000008",
+      "icount": "1",
+      "xis": "elx.r00001",
+      "cf": "nap",
+      "gw": "god",
+      "forms": [
+        {
+          "n": "nap"
+        }
+      ],
+      "norms": [
+        {
+          "n": "nap"
+        }
+      ],
+      "senses": [
+        {
+          "mng": "god"
+        }
+      ],
+      "periods": [
+        {
+          "p": "Neo-Assyrian"
+        }
+      ]
+    }
+  ],
+  "instances": {
+    "elx.r00001": [
+      "dcclt/nineveh:P365771.126.1"
+    ]
+  }
+}

--- a/tests/test_break_down.py
+++ b/tests/test_break_down.py
@@ -39,6 +39,19 @@ def missing_instances_glossary():
     return original_data, 1
 
 
+@pytest.fixture(scope="module",
+                params=[
+                  ('tests/gloss-elx.json', 'tests/gloss-elx-preprocessed.json'),
+                ])
+def preprocessing_pair(request):
+    """Return the filename of a glossary and the result of preprocessing it."""
+    input_file = request.param[0]
+    expected_output_file = request.param[1]
+    with open(expected_output_file, 'r') as f:
+        expected_data = json.load(f)
+    return input_file, expected_data
+
+
 def test_process_file(direct_fields, indirect_fields):
     """Test that we can break down a small glossary correctly."""
     input_name = "tests/gloss-elx.json"  # modified from the original
@@ -79,15 +92,11 @@ def test_missing_instances(missing_instances_glossary):
     assert len(processed_data) == len(original_data["entries"]) - missing_number
 
 
-def test_preprocess():
+def test_preprocess(preprocessing_pair):
     """Test that the preprocessing step gives the expected results."""
-    # TODO Can parametrise this to test other sample files
     # TODO Should we check the properties of the output data (e.g. keys, length)
     # rather than compare it to a fixed output?
-    input_file = 'tests/gloss-elx.json'
-    expected_output_file = 'tests/gloss-elx-preprocessed.json'
-    with open(expected_output_file, 'r') as f:
-        expected_data = json.load(f)
+    input_file, expected_data = preprocessing_pair
     output_data = preprocess_glossary(input_file)
     assert output_data == expected_data
 

--- a/tests/test_break_down.py
+++ b/tests/test_break_down.py
@@ -4,6 +4,7 @@ import pytest
 
 from ingest.break_down import (
     name_and_type,
+    preprocess_glossary,
     process_file,
     process_glossary_data,
     base_fields,
@@ -76,6 +77,19 @@ def test_missing_instances(missing_instances_glossary):
     with pytest.warns(UserWarning):
         processed_data = process_glossary_data(original_data)
     assert len(processed_data) == len(original_data["entries"]) - missing_number
+
+
+def test_preprocess():
+    """Test that the preprocessing step gives the expected results."""
+    # TODO Can parametrise this to test other sample files
+    # TODO Should we check the properties of the output data (e.g. keys, length)
+    # rather than compare it to a fixed output?
+    input_file = 'tests/gloss-elx.json'
+    expected_output_file = 'tests/gloss-elx-preprocessed.json'
+    with open(expected_output_file, 'r') as f:
+        expected_data = json.load(f)
+    output_data = preprocess_glossary(input_file)
+    assert output_data == expected_data
 
 
 def test_name_and_type():

--- a/tests/test_break_down.py
+++ b/tests/test_break_down.py
@@ -101,6 +101,28 @@ def test_preprocess(preprocessing_pair):
     assert output_data == expected_data
 
 
+def test_preprocess_no_jq(monkeypatch):
+    """Test that the preprocessing step raises an error if jq is not found."""
+    monkeypatch.setenv("PATH", "")
+    with pytest.raises(RuntimeError):
+        preprocess_glossary("tests/gloss-elx.json")
+
+
+def test_process_file_no_jq(monkeypatch):
+    """
+    Test that a file can be processed if jq is not found, but that a warning
+    is raised.
+    """
+    input_file = "tests/gloss-elx.json"
+    monkeypatch.setenv("PATH", "")
+    with pytest.warns(RuntimeWarning) as warning:
+        process_file(input_file, write_file=False)
+    # Check that the filename is present in the warning message
+    assert len(warning) == 1
+    assert input_file in warning[0].message.args[0]
+    # TODO Could check the validity of the result here
+
+
 def test_name_and_type():
     """Test that the breaking down of field specs into name and type works."""
     # Check that we return the right name and str when there is no type given


### PR DESCRIPTION
Fixes #19 by preprocessing the glossary files to remove the fields we don't need. It's possible that we can improve this further - for example, we may want to see if we can restructure to do the indexing earlier on, or to avoid the intermediate glossary file.

- [x] Use `jq` to remove all fields that are unused.
- [x] Warn explicitly about unresolved references to instances.
- [x] Add a test for the `jq` part specifically (the overall breakdown is already covered).

This has been rebased on #20, which should be merged first, but may eventually need refreshing! (although so far they touch different parts of the code)

- [x] Change the base branch to `development` once #20 is merged! (or rebase this branch onto `development` if not)