### PR TITLE
Use ASCII synonyms for non-ASCII characters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
 
 before_script:
   - sleep 10 # While ElasticSearch starts up (as per Travis docs)
+  - sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-icu
 
 script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ matrix:
     - python: '3.6'
       env: PEP8=1
 
-services:
-  - elasticsearch
-
 install:
   - pip install -r requirements.txt
   - |
@@ -22,9 +19,13 @@ install:
     fi
 
 before_script:
-  - sleep 10 # While ElasticSearch starts up (as per Travis docs)
-  - sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-icu
-  - sudo service elasticsearch restart
+  - |
+    # Install plugin and start ElasticSearch if not on the PEP8 test instance
+    if [ -z "$PEP8" ]; then
+      sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-icu
+      sudo service elasticsearch start
+      sleep 10 # While ElasticSearch starts up (as per Travis docs)
+    fi
 
 script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ install:
 before_script:
   - sleep 10 # While ElasticSearch starts up (as per Travis docs)
   - sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-icu
+  - sudo service elasticsearch restart
 
 script:
   - |

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ For more installation instructions and options, see
 To store Oracc's texts and their related metadata, we use
 [ElasticSearch](https://www.elastic.co/products/elasticsearch). The code in
 this repository has been tested with ElasticSearch 6.
+In particular, **it is not (yet) compatible with ElasticSearch 7!**
 
 To install ElasticSearch:
 * OS X: `brew install elasticsearch`

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ To install it:
 * OS X: `elasticsearch-plugin install analysis-icu`
 * Ubuntu: `sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-icu` (as per link above)
 
+Note that, after installing the plugin, if ElasticSearch was already running then each node has to be restarted.
+If running as a service (like in the instructions below), all nodes can be restarted with one command:
+* OS X: `brew services restart elasticsearch`
+* Ubuntu: `sudo service elasticsearch restart`
+
 To launch an instance of ElasticSearch accessible in its default port 9200:
 * OS X: `elasticsearch -d`
 * Ubuntu: `systemctl start elasticsearch`

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ curl -XGET localhost:5000/search/water
 ```
 
 This searches multiple fields for the given query word and returns all
-results. The list of fields currently searched is: `headword`, `gw`
-(guideword), `cf` (cuneiform), `senses.mng` (meaning), `forms.n` and `norms.n`
+results. The list of fields currently searched is: `gw` (guideword),
+`cf` (cuneiform), `senses.mng` (meaning), `forms.n` and `norms.n`
 (lemmatisations).
 
 The matching is not exact: an entry is considered to match a query word if it
@@ -136,9 +136,9 @@ no matches are found, a 204 (No Content) status code is returned.
 
 An older, simpler search mode can also be accessed at the `/search` endpoint:
 ```
-curl -XGET localhost:5000/search -d 'headword=water'
+curl -XGET localhost:5000/search -d 'gw=water'
 ```
-This mode supports searching a single field (e.g. headword) for the given value.
+This mode supports searching a single field (e.g. guideword) for the given value.
 If more than one fields are specified (or if none are), an error will be
 returned. This does not accept the extra parameters described below, and should
 be considered deprecated.
@@ -147,7 +147,7 @@ be considered deprecated.
 
 You can customise the search by optionally specifying additional parameters.
 These are:
-- `sort_by`: the field on which to sort (`headword`, `gw`, `cf` or `icount`)
+- `sort_by`: the field on which to sort (`gw`, `cf` or `icount`)
 - `dir`: the sorting order, ascending (`asc`) or descending (`desc`)
 - `count`: the maximum number of results
 

--- a/ingest/bulk_upload.py
+++ b/ingest/bulk_upload.py
@@ -6,7 +6,7 @@ import elasticsearch.client
 import elasticsearch.helpers
 
 from .break_down import process_file
-
+from .prepare_index import ICU_installed, create_index
 
 INDEX_NAME = "oracc"
 TYPE_NAME = "entry"
@@ -25,64 +25,6 @@ def upload_entries(es, entries):
 
 def upload_file(es, input_file):
     upload_entries(es, process_file(input_file, write_file=False))
-
-
-def ICU_installed(es):
-    """Check whether the ICU Analysis plugin is installed locally."""
-    cc = elasticsearch.client.CatClient(es)
-    return 'analysis-icu' in [p['component'] for p in cc.plugins(format="json")]
-
-
-def prepare_index_settings():
-    """Create the mapping and settings to be used for the index.
-
-    These must be specified before ingesting the data, so that the fields are
-    properly populated.
-    """
-    # Some fields will contain non-ASCII characters. We want these characters
-    # to be searchable by some equivalent ASCII sequences, according to the
-    # Oracc conventions. For this, we need a custom analyzer that will replace
-    # the non-ASCII characters with their "equivalents".
-    analysis_properties = {
-        "analyzer": {
-            "cuneiform_analyzer": {
-                # The standard tokenizer will remove "," and ".", which are
-                # used in some substitution sequences; instead, we can break
-                # tokens on whitespace, which will ignore punctuation.
-                "tokenizer": "whitespace",
-                "filter": ["lowercase"],
-                "char_filter": ["cuneiform_to_ascii"]
-            }
-        },
-        # For the list of character substitutions, see
-        # http://oracc.museum.upenn.edu/doc/search/searchingcorpora/index.html#h_asciinonunicode
-        "char_filter": {
-            "cuneiform_to_ascii": {
-                "type": "mapping",
-                "mappings": [
-                    "š => sz",
-                    "ṣ => s."
-                ]
-            }
-        }
-    }
-    # Create an additional field used for sorting. The new field is called
-    # cf.sort and will use a locale-aware collation.
-    field_properties = {
-        "cf": {
-            "type": "text",
-            "analyzer": "cuneiform_analyzer",
-            "fields": {
-                "sort": {
-                    "type": "icu_collation_keyword"
-                }
-            }
-        }
-    }
-
-    settings = {"analysis": analysis_properties}
-    mappings = {"properties": field_properties}
-    return settings, mappings
 
 
 if __name__ == "__main__":
@@ -109,10 +51,7 @@ if __name__ == "__main__":
             debug("Index not found, continuing")
 
     # Create the index with the required settings
-    settings, mappings = prepare_index_settings()
-    client.create(index=INDEX_NAME, body={"settings": settings})
-    client.put_mapping(index=INDEX_NAME, doc_type=TYPE_NAME,
-                       body=mappings)
+    create_index(es, INDEX_NAME, TYPE_NAME)
 
     for file in files:
         # Break down into individual entries and upload to ES using the bulk API

--- a/ingest/bulk_upload.py
+++ b/ingest/bulk_upload.py
@@ -6,7 +6,7 @@ import elasticsearch.client
 import elasticsearch.helpers
 
 from .break_down import process_file
-from .prepare_index import ICU_installed, create_index
+from .prepare_index import create_index
 
 INDEX_NAME = "oracc"
 TYPE_NAME = "entry"
@@ -25,6 +25,12 @@ def upload_entries(es, entries):
 
 def upload_file(es, input_file):
     upload_entries(es, process_file(input_file, write_file=False))
+
+
+def ICU_installed(es):
+    """Check whether the ICU Analysis plugin is installed locally."""
+    cc = elasticsearch.client.CatClient(es)
+    return 'analysis-icu' in [p['component'] for p in cc.plugins(format="json")]
 
 
 if __name__ == "__main__":

--- a/ingest/prepare_index.py
+++ b/ingest/prepare_index.py
@@ -1,6 +1,6 @@
 """Methods for creating an index for Oracc glossary data."""
 import elasticsearch
-from elasticsearch_dsl import analyzer, char_filter
+from elasticsearch_dsl import analyzer, char_filter, Index
 
 
 def ICU_installed(es):
@@ -9,39 +9,12 @@ def ICU_installed(es):
     return 'analysis-icu' in [p['component'] for p in cc.plugins(format="json")]
 
 
-def prepare_index_settings():
-    """Create the mapping and settings to be used for the index.
+def prepare_index_mapping():
+    """Create the mapping to be used for the index.
 
     These must be specified before ingesting the data, so that the fields are
     properly populated.
     """
-    # Some fields will contain non-ASCII characters. We want these characters
-    # to be searchable by some equivalent ASCII sequences, according to the
-    # Oracc conventions. For this, we need a custom analyzer that will replace
-    # the non-ASCII characters with their "equivalents".
-    analysis_properties = {
-        "analyzer": {
-            "cuneiform_analyzer": {
-                # The standard tokenizer will remove "," and ".", which are
-                # used in some substitution sequences; instead, we can break
-                # tokens on whitespace, which will ignore punctuation.
-                "tokenizer": "whitespace",
-                "filter": ["lowercase"],
-                "char_filter": ["cuneiform_to_ascii"]
-            }
-        },
-        # For the list of character substitutions, see
-        # http://oracc.museum.upenn.edu/doc/search/searchingcorpora/index.html#h_asciinonunicode
-        "char_filter": {
-            "cuneiform_to_ascii": {
-                "type": "mapping",
-                "mappings": [
-                    "š => sz",
-                    "ṣ => s."
-                ]
-            }
-        }
-    }
     # Create an additional field used for sorting. The new field is called
     # cf.sort and will use a locale-aware collation.
     field_properties = {
@@ -55,10 +28,8 @@ def prepare_index_settings():
             }
         }
     }
-
-    settings = {"analysis": analysis_properties}
     mappings = {"properties": field_properties}
-    return settings, mappings
+    return mappings
 
 
 def prepare_cuneiform_analyzer():
@@ -108,8 +79,8 @@ def create_index(es, index_name, type_name):
     :param index_name: the name of the index to create
     :param type_name: the name of the document type to apply the mappings to
     """
-    client = elasticsearch.client.IndicesClient(es)
-    settings, mappings = prepare_index_settings()
-    client.create(index=index_name, body={"settings": settings})
-    client.put_mapping(index=index_name, doc_type=type_name,
-                       body=mappings)
+    index = Index(index_name)
+    index.analyzer(prepare_cuneiform_analyzer())
+    index.create(using=es)
+    mappings = prepare_index_mapping()
+    index.put_mapping(using=es, doc_type=type_name, body=mappings)

--- a/ingest/prepare_index.py
+++ b/ingest/prepare_index.py
@@ -30,13 +30,11 @@ def prepare_cuneiform_analyzer():
     https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis.html
     """
     # First we define the character filter that will do the replacement.
+    synonyms = {"ḫ": "h", "ŋ": "j", "ṣ": "s,", "š": "sz", "ṭ": "t,"}
     cuneiform_to_ascii = char_filter(
         CHAR_FILTER_NAME,
         type="mapping",
-        mappings=[
-            "š => sz",
-            "ṣ => s,"
-        ]
+        mappings=["{} => {}".format(*pair) for pair in synonyms.items()],
     )
     # Now we define the analyzer using this character filter and some builtins.
     cuneiform_analyzer = analyzer(

--- a/ingest/prepare_index.py
+++ b/ingest/prepare_index.py
@@ -1,12 +1,5 @@
 """Methods for creating an index for Oracc glossary data."""
-import elasticsearch
 from elasticsearch_dsl import analyzer, char_filter, Index
-
-
-def ICU_installed(es):
-    """Check whether the ICU Analysis plugin is installed locally."""
-    cc = elasticsearch.client.CatClient(es)
-    return 'analysis-icu' in [p['component'] for p in cc.plugins(format="json")]
 
 
 def prepare_index_mapping():

--- a/ingest/prepare_index.py
+++ b/ingest/prepare_index.py
@@ -1,0 +1,78 @@
+"""Methods for creating an index for Oracc glossary data."""
+import elasticsearch
+
+
+def ICU_installed(es):
+    """Check whether the ICU Analysis plugin is installed locally."""
+    cc = elasticsearch.client.CatClient(es)
+    return 'analysis-icu' in [p['component'] for p in cc.plugins(format="json")]
+
+
+def prepare_index_settings():
+    """Create the mapping and settings to be used for the index.
+
+    These must be specified before ingesting the data, so that the fields are
+    properly populated.
+    """
+    # Some fields will contain non-ASCII characters. We want these characters
+    # to be searchable by some equivalent ASCII sequences, according to the
+    # Oracc conventions. For this, we need a custom analyzer that will replace
+    # the non-ASCII characters with their "equivalents".
+    analysis_properties = {
+        "analyzer": {
+            "cuneiform_analyzer": {
+                # The standard tokenizer will remove "," and ".", which are
+                # used in some substitution sequences; instead, we can break
+                # tokens on whitespace, which will ignore punctuation.
+                "tokenizer": "whitespace",
+                "filter": ["lowercase"],
+                "char_filter": ["cuneiform_to_ascii"]
+            }
+        },
+        # For the list of character substitutions, see
+        # http://oracc.museum.upenn.edu/doc/search/searchingcorpora/index.html#h_asciinonunicode
+        "char_filter": {
+            "cuneiform_to_ascii": {
+                "type": "mapping",
+                "mappings": [
+                    "š => sz",
+                    "ṣ => s."
+                ]
+            }
+        }
+    }
+    # Create an additional field used for sorting. The new field is called
+    # cf.sort and will use a locale-aware collation.
+    field_properties = {
+        "cf": {
+            "type": "text",
+            "analyzer": "cuneiform_analyzer",
+            "fields": {
+                "sort": {
+                    "type": "icu_collation_keyword"
+                }
+            }
+        }
+    }
+
+    settings = {"analysis": analysis_properties}
+    mappings = {"properties": field_properties}
+    return settings, mappings
+
+
+def create_index(es, index_name, type_name):
+    """
+    Create an index to handle glossary data.
+
+    This will apply the necessary settings and mappings so that data can be
+    processed and searched correctly.
+
+    :param es: an Elasticsearch instance to connect to
+    :param index_name: the name of the index to create
+    :param type_name: the name of the document type to apply the mappings to
+    """
+    client = elasticsearch.client.IndicesClient(es)
+    settings, mappings = prepare_index_settings()
+    client.create(index=index_name, body={"settings": settings})
+    client.put_mapping(index=index_name, doc_type=type_name,
+                       body=mappings)

--- a/ingest/prepare_index.py
+++ b/ingest/prepare_index.py
@@ -60,7 +60,7 @@ def prepare_index_mapping(doc_type):
     # cf.sort and will use a locale-aware collation.
     # The base cf field will use the custom cuneiform analyzer.
     mappings.field("cf", "text", analyzer=ANALYZER_NAME,
-                   fields={"sort": ICUKeywordField})
+                   fields={"sort": ICUKeywordField()})
     return mappings
 
 
@@ -77,5 +77,5 @@ def create_index(es, index_name, type_name):
     """
     index = Index(index_name)
     index.analyzer(prepare_cuneiform_analyzer())
-    index.mappings(prepare_index_mapping(type_name))
+    index.mapping(prepare_index_mapping(type_name))
     index.create(using=es)

--- a/ingest/prepare_index.py
+++ b/ingest/prepare_index.py
@@ -35,7 +35,7 @@ def prepare_cuneiform_analyzer():
         type="mapping",
         mappings=[
             "š => sz",
-            "ṣ => s."
+            "ṣ => s,"
         ]
     )
     # Now we define the analyzer using this character filter and some builtins.

--- a/ingest/prepare_index.py
+++ b/ingest/prepare_index.py
@@ -61,6 +61,11 @@ def prepare_index_mapping(doc_type):
     # The base cf field will use the custom cuneiform analyzer.
     mappings.field("cf", "text", analyzer=ANALYZER_NAME,
                    fields={"sort": ICUKeywordField()})
+    # Also use the analyzer for other fields which contain cuneiform text.
+    for field in ["forms_n", "norms_n"]:
+        # TODO Do we lose anything by making this mapping explicit? (compared
+        # to the dynamic mapping created by Elasticsearch automatically)
+        mappings.field(field, "text", analyzer=ANALYZER_NAME)
     return mappings
 
 

--- a/ingest/prepare_index.py
+++ b/ingest/prepare_index.py
@@ -30,7 +30,18 @@ def prepare_cuneiform_analyzer():
     https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis.html
     """
     # First we define the character filter that will do the replacement.
-    synonyms = {"ḫ": "h", "ŋ": "j", "ṣ": "s,", "š": "sz", "ṭ": "t,"}
+    synonyms = {"ḫ": "h", "ŋ": "j", "ṣ": "s,", "š": "sz", "ṭ": "t,",
+                # Unicode "positions" of vowel variants do not follow any
+                # pattern, so they must be listed explicitly:
+                "á": "a2", "à": "a3", "â": "a", "ā": "a",
+                "é": "e2", "è": "e3", "ê": "e", "ē": "e",
+                "í": "i2", "ì": "i3", "î": "i", "ī": "i",
+                "ú": "u2", "ù": "u3", "û": "u", "ū": "u",
+                }
+    # Numerical subscript characters (₀, ₁, etc) run contiguously from 0x2080.
+    # We map them to their "normal" digits, so that e.g. ₁ is matched by 1.
+    for digit in range(10):
+        synonyms[chr(8320 + digit)] = str(digit)
     cuneiform_to_ascii = char_filter(
         CHAR_FILTER_NAME,
         type="mapping",

--- a/ingest/prepare_index.py
+++ b/ingest/prepare_index.py
@@ -80,7 +80,7 @@ def create_index(es, index_name, type_name):
     :param index_name: the name of the index to create
     :param type_name: the name of the document type to apply the mappings to
     """
-    index = Index(index_name)
+    index = Index(index_name, doc_type=type_name)
     index.analyzer(prepare_cuneiform_analyzer())
     index.mapping(prepare_index_mapping(type_name))
     index.create(using=es)

--- a/oracc_rest/search.py
+++ b/oracc_rest/search.py
@@ -4,7 +4,7 @@ from elasticsearch_dsl import Q, Search
 
 
 class ESearch:
-    FIELDNAMES = ['headword', 'gw', 'cf', 'forms_n', 'norms_n', 'senses_mng']
+    FIELDNAMES = ['gw', 'cf', 'forms_n', 'norms_n', 'senses_mng']
     TEXT_FIELDS = ['gw']  # fields with text content on which we can sort
     UNICODE_FIELDS = ['cf']  # fields which may contain non-ASCII characters
 

--- a/oracc_rest/search.py
+++ b/oracc_rest/search.py
@@ -27,7 +27,7 @@ class ESearch:
         results = search.sort("_doc").scan()
         return results
 
-    def _execute_general(self, phrase, sort_by="cf", dir="asc",
+    def _execute_general(self, phrase, sort_by="cf", direction="asc",
                          count=None, after=None):
         """
         Given a phrase of space-separated words, return all matching entries in
@@ -50,7 +50,7 @@ class ESearch:
         search = (
                 Search(using=self.client, index=self.index)
                 .query("bool", must=subqueries)
-                .sort(self._sort_field_name(sort_by, dir))
+                .sort(self._sort_field_name(sort_by, direction))
                 )
         return self._customise_and_run(search, count, after)
 
@@ -82,13 +82,13 @@ class ESearch:
         else:
             return self._get_results(self._execute(word, fieldname))
 
-    def list_all(self, sort_by="cf", dir="asc", count=None, after=None):
+    def list_all(self, sort_by="cf", direction="asc", count=None, after=None):
         """Get a list of all entries."""
         search = (
                 Search(using=self.client, index=self.index)
                 .query("match_all")
                 # TODO We should maybe sort on a tie-breaker field (eg _id) too...
-                .sort(self._sort_field_name(sort_by, dir))
+                .sort(self._sort_field_name(sort_by, direction))
                 )
         results = self._customise_and_run(search, count, after)
         return self._get_results(results)
@@ -114,11 +114,11 @@ class ESearch:
             results = search.params(preserve_order=True).scan()
         return results
 
-    def _sort_field_name(self, field, dir):
+    def _sort_field_name(self, field, direction):
         """Build the argument to sort based on a field name and a direction."""
         return "{}{}{}".format(
             # A - indicates descending sorting order in the ElasticSearch DSL
-            "-" if dir == 'desc' else "",
+            "-" if direction == 'desc' else "",
             # The base field name
             field,
             # Potentially, a suffix for the field:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 flask-cors
 flask_restful
-elasticsearch_dsl >= 6
+elasticsearch_dsl ~= 6.0
 pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import json
+import time
 import warnings
 
 from elasticsearch import Elasticsearch, exceptions
@@ -35,3 +36,18 @@ def entries():
     """An example list of JSON glossary entries."""
     with open("tests/gloss-elx-out.json", "r") as entries_file:
         return json.load(entries_file)
+
+
+@pytest.fixture
+def uploaded_entries(es, entries, test_index_name):
+    """A fixture to ensure that the test glossary entries have been uploaded."""
+    ingest.bulk_upload.upload_entries(es, entries)
+    # Wait until the upload has finished, but give up after about 10 seconds.
+    number_attempts = 20  # how many times to check before giving up
+    delay = 0.5  # how long to sleep between attempts
+    for _ in range(number_attempts):
+        if es.count(index=test_index_name)["count"] == len(entries):
+            return entries  # all uploaded!
+        else:
+            time.sleep(delay)
+    assert False  # raise an error if upload not complete after all attempts

--- a/tests/test_bulk_upload.py
+++ b/tests/test_bulk_upload.py
@@ -1,6 +1,22 @@
 import time
 
+from elasticsearch_dsl import Index
+
 import ingest.bulk_upload
+from ingest.prepare_index import ANALYZER_NAME, prepare_cuneiform_analyzer
+
+
+def test_analyzer(es, test_index_name):
+    """Test that the analyzer follows the Oracc non-ASCII representation."""
+    analyzer = prepare_cuneiform_analyzer()
+    index = Index(test_index_name)
+    index.analyzer(analyzer)
+    index.create(using=es)
+    # Check various character substitutions work
+    for (text, analyzed) in [("apši", "apszi"), ("ṣa", "s,a")]:
+        response = index.analyze(
+            using=es, body={"text": text, "analyzer": ANALYZER_NAME})
+        assert response["tokens"][0]["token"] == analyzed
 
 
 def test_upload_entries(es, entries, test_index_name):

--- a/tests/test_bulk_upload.py
+++ b/tests/test_bulk_upload.py
@@ -19,6 +19,12 @@ def test_analyzer(es, test_index_name):
         response = index.analyze(
             using=es, body={"text": original, "analyzer": ANALYZER_NAME})
         assert response["tokens"][0]["token"] == analyzed
+    # Check a text consisting of multiple words
+    combined_original = " ".join(original_texts)
+    response = index.analyze(
+        using=es, body={"text": combined_original, "analyzer": ANALYZER_NAME})
+    tokens = [block["token"] for block in response["tokens"]]
+    assert tokens == analyzed_texts
 
 
 def test_upload_entries(es, entries, test_index_name):

--- a/tests/test_bulk_upload.py
+++ b/tests/test_bulk_upload.py
@@ -1,9 +1,10 @@
 import time
 
-from elasticsearch_dsl import Index
+from elasticsearch_dsl import Index, Search
 
 import ingest.bulk_upload
-from ingest.prepare_index import ANALYZER_NAME, prepare_cuneiform_analyzer
+from ingest.prepare_index import (ANALYZER_NAME, create_index,
+                                  prepare_cuneiform_analyzer)
 
 
 def test_analyzer(es, test_index_name):
@@ -34,3 +35,17 @@ def test_upload_entries(es, entries, test_index_name):
     time.sleep(2)  # a small delay to make sure the upload has finished
     # Check that all documents have been uploaded
     assert es.count(index=test_index_name)["count"] == len(entries)
+
+
+def test_analyzer_search_results(es, entries, test_index_name):
+    """Test that the analyzer works as expected at search time."""
+    # Create the index with all the required settings
+    create_index(es, test_index_name, ingest.bulk_upload.TYPE_NAME)
+    ingest.bulk_upload.upload_entries(es, entries)
+    time.sleep(2)  # a small delay to make sure the upload has finished
+    # The test entries include "apši". Check that its ASCII transliteration
+    # can be retrieved.
+    search = Search(using=es, index=test_index_name).query("match", cf="apszi")
+    results = search.execute()
+    assert len(results) == 1  # would be 0 if no results found
+    assert results[0].cf == "apši"

--- a/tests/test_bulk_upload.py
+++ b/tests/test_bulk_upload.py
@@ -13,9 +13,11 @@ def test_analyzer(es, test_index_name):
     index.analyzer(analyzer)
     index.create(using=es)
     # Check various character substitutions work
-    for (text, analyzed) in [("apši", "apszi"), ("ṣa", "s,a")]:
+    original_texts = ["ḫa", "ŋen", "ṣa", "ša", "ṭa"]
+    analyzed_texts = ["ha", "jen", "s,a", "sza", "t,a"]
+    for (original, analyzed) in zip(original_texts, analyzed_texts):
         response = index.analyze(
-            using=es, body={"text": text, "analyzer": ANALYZER_NAME})
+            using=es, body={"text": original, "analyzer": ANALYZER_NAME})
         assert response["tokens"][0]["token"] == analyzed
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,24 +1,4 @@
-import time
-
-import pytest
-
-import ingest.bulk_upload
 from oracc_rest import ESearch
-
-
-@pytest.fixture
-def uploaded_entries(es, entries, test_index_name):
-    """A fixture to ensure that the test glossary entries have been uploaded."""
-    ingest.bulk_upload.upload_entries(es, entries)
-    # Wait until the upload has finished, but give up after about 10 seconds.
-    number_attempts = 20  # how many times to check before giving up
-    delay = 0.5  # how long to sleep between attempts
-    for _ in range(number_attempts):
-        if es.count(index=test_index_name)["count"] == len(entries):
-            return entries  # all uploaded!
-        else:
-            time.sleep(delay)
-    assert False  # raise an error if upload not complete after all attempts
 
 
 def test_sort_field_name():


### PR DESCRIPTION
Will fix #18.

- [x] Add a new analyzer for the fields that may contain non-ASCII characters (`gw`, `cf`, `norms_n` and `norms_f` fields)
- [x] Stop indexing the `headword` field (not necessary but removes duplication)
- [ ] Make sure that the preprocessing does not remove any non-ASCII characters! (e.g. that Unicode sequences are understood correctly)
- [x] Test that the analyzer specification is correct based on the expected substitutions (see examples on [the official docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/_testing_analyzers.html))
- [ ] Test that other fields like `cf.sort` behave as before, i.e. don't use the new analyzer
- [x] Test that searching with ASCII substitutions works as expected